### PR TITLE
updating the base64 encoding method

### DIFF
--- a/Py3/CyWebSocket.py
+++ b/Py3/CyWebSocket.py
@@ -183,7 +183,7 @@ class socketIO():
                                 unit = data.split(": ")
                                 header[unit[0]] = unit[1]
                         secKey = header['Sec-WebSocket-Key']
-                        resKey = base64.encodestring(hashlib.new("sha1",(secKey+"258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode('utf-8')).digest())
+                        resKey = base64.b64encode(hashlib.new("sha1",(secKey+"258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode('utf-8')).digest())
                         resKey = resKey.decode().replace("\n","")
                         response = '''HTTP/1.1 101 Switching Protocols\r\n'''
                         response += '''Upgrade: websocket\r\n'''


### PR DESCRIPTION
seems like encodestring() is depricated since Python 3.1 and b64encode() should be used instead. 

> base64.encodestring() and base64.decodestring(), aliases deprecated since Python 3.1, have been removed: use [base64.encodebytes()](https://docs.python.org/3/library/base64.html#base64.encodebytes) and [base64.decodebytes()](https://docs.python.org/3/library/base64.html#base64.decodebytes) instead. (Contributed by Victor Stinner in [bpo-39351](https://bugs.python.org/issue?@action=redirect&bpo=39351).)

tested on vanilla **Python 3.9.5** which throws:

`AttributeError: module 'base64' has no attribute 'encodestring'`